### PR TITLE
fix: GetLastCommand not working with powershell inside windows terminal

### DIFF
--- a/Fix.Tests/ConsoleFixers/GitSimilarCommandTests.cs
+++ b/Fix.Tests/ConsoleFixers/GitSimilarCommandTests.cs
@@ -1,4 +1,3 @@
-using Fix.ConsoleHelpers;
 using Fix.CommandFixers;
 using System;
 using Xunit;
@@ -26,6 +25,28 @@ C:\dev\app>fix
             Assert.True(fix.IsFixed);
             Assert.Equal(nameof(GitSimilar), fix.Author);
             Assert.Equal("git status", fix.FixedCommand);
+        }
+
+        [Fact]
+        public void Can_fix_git_status_from_windows_terminal()
+        {
+            var consoleBuffer = @"PS C:\dev\app> git pu
+git: 'pu' is not a git command. See 'git --help'.
+
+The most similar command is
+        pull
+        push
+        p4
+PS C:\dev\app> fix
+";
+            var lines = consoleBuffer.Split(Environment.NewLine);
+
+            var manager = SetupTestsHelper.CreateActionManager();
+            var fix = manager.GetFix(lines);
+
+            Assert.True(fix.IsFixed);
+            Assert.Equal(nameof(GitSimilar), fix.Author);
+            Assert.Equal("git pull", fix.FixedCommand);
         }
     }
 }

--- a/Fix/CommandFixers/ActionManager.cs
+++ b/Fix/CommandFixers/ActionManager.cs
@@ -1,5 +1,7 @@
 ﻿using Fix.ConsoleHelpers;
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Fix.CommandFixers
@@ -18,7 +20,9 @@ namespace Fix.CommandFixers
         private string GetLastCommand(string[] lines)
         {
             var currentPath = ConsoleHelper.GetCurrentPath();
-            var lastCommandLine = lines.Where(x => x.StartsWith(currentPath + ConsoleHelper.CONSOLE_SEPARATOR))
+            var commandPrefix = currentPath + ConsoleHelper.CONSOLE_SEPARATOR;
+            var commandPrefixWithPS = "PS " + commandPrefix;
+            var lastCommandLine = lines.Where(x => x.StartsWith(commandPrefix) || x.StartsWith(commandPrefixWithPS))
                                        .Reverse()
                                        .Skip(1)
                                        .FirstOrDefault();
@@ -27,7 +31,7 @@ namespace Fix.CommandFixers
                 return "";
             }
             var index = lastCommandLine.IndexOf(ConsoleHelper.CONSOLE_SEPARATOR);
-            return lastCommandLine[(index + 1)..];
+            return lastCommandLine[(index + 1)..].Trim();
         }
 
         private string[] FilterLastCommand(string lastCommand, string[] lines)

--- a/Fix/CommandFixers/ActionManager.cs
+++ b/Fix/CommandFixers/ActionManager.cs
@@ -1,13 +1,14 @@
 ﻿using Fix.ConsoleHelpers;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Fix.CommandFixers
 {
     public class ActionManager
     {
+        private static readonly Regex _normalizerRegex = new("^(PS )(.*>)(\\s)?(.*)", RegexOptions.Compiled);
         private List<ICommandFixer> _fixActions = new();
 
         public string LastCommand { get; private set; } = "";
@@ -17,12 +18,11 @@ namespace Fix.CommandFixers
             _fixActions.Add(fixAction);
         }
 
-        private string GetLastCommand(string[] lines)
+        private string GetLastCommand(IEnumerable<string> lines)
         {
             var currentPath = ConsoleHelper.GetCurrentPath();
             var commandPrefix = currentPath + ConsoleHelper.CONSOLE_SEPARATOR;
-            var commandPrefixWithPS = "PS " + commandPrefix;
-            var lastCommandLine = lines.Where(x => x.StartsWith(commandPrefix) || x.StartsWith(commandPrefixWithPS))
+            var lastCommandLine = lines.Where(x => x.StartsWith(commandPrefix))
                                        .Reverse()
                                        .Skip(1)
                                        .FirstOrDefault();
@@ -34,20 +34,22 @@ namespace Fix.CommandFixers
             return lastCommandLine[(index + 1)..].Trim();
         }
 
-        private string[] FilterLastCommand(string lastCommand, string[] lines)
+        private string[] FilterLastCommand(string lastCommand, IEnumerable<string> lines)
         {
             var currentPath = ConsoleHelper.GetCurrentPath();
+            var fullLastCommand = $"{currentPath}{ConsoleHelper.CONSOLE_SEPARATOR}{lastCommand}";
             return lines.Reverse()
                         .Skip(1)
-                        .TakeWhile(x => x != $"{currentPath}{ConsoleHelper.CONSOLE_SEPARATOR}{lastCommand}")
+                        .TakeWhile(x => x != fullLastCommand)
                         .Reverse()
                         .ToArray();
         }
 
         public CommandFix GetFix(string[] consoleBufferInLines)
         {
-            LastCommand = GetLastCommand(consoleBufferInLines);
-            var lastCommandResult = FilterLastCommand(LastCommand, consoleBufferInLines);
+            var normalizedBuffer = consoleBufferInLines.Select(s => _normalizerRegex.Replace(s, "$2$4"));
+            LastCommand = GetLastCommand(normalizedBuffer);
+            var lastCommandResult = FilterLastCommand(LastCommand, normalizedBuffer);
 
             LogBuffer(lastCommandResult);
 

--- a/Fix/Program.cs
+++ b/Fix/Program.cs
@@ -9,11 +9,12 @@ namespace Fix
     {
         static void Main(string[] args)
         {
-            if(args.Any(x => x == "-debug"))
+            if(args.Contains("-debug"))
             {
                 ConsoleHelper.Debug = true;
             }
-            if (args.Any(x => x == "-plan"))
+
+            if (args.Contains("-plan"))
             {
                 ConsoleHelper.Plan = true;
             }
@@ -23,6 +24,7 @@ namespace Fix
             if (lines.Length < 3)
             {
                 Console.WriteLine("Nothing to fix");
+                return;
             }
             
             var actionManager = new ActionManagerFactory().Create();


### PR DESCRIPTION
The GetLastCommand method was returning null when executing 'fix' on a Powershell instance inside Windows Terminal, which has a 'PS' prefix like the snippet below.
`PS C:\Users\Ronald\Desktop\projects\fix\Fix\bin\Debug\net5.0\win-x64> git pu`

Fixers were also not working because besides the prefix, there is also a space between the '>' characters and the actual command.