### PR TITLE
Point to latest release for downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ C:\dev>az login
 - Dotnet 5.0 installed
 
 ## Instalation
-- Just copy the [fix.exe](https://github.com/andrecarlucci/fix/releases/tag/v0.1) file to your path.
+- Just copy the [fix.exe](https://github.com/andrecarlucci/fix/releases/latest) file to your path.
 
 ## Switches
 - fix.exe -debug : shows debug information.


### PR DESCRIPTION
The current README points to release v0.1. It should, however, point to v0.3 - or simply to the latest release. This PR fixes that.